### PR TITLE
fix the postgresql section 

### DIFF
--- a/charts/fuse/Chart.yaml
+++ b/charts/fuse/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fuse
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4
 description: Fuse syncs data from Git into a SQL database for use in BI/visualization/other tools.
 home: https://www.mergestat.com/
 icon: https://github.com/mergestat/mergestat/blob/main/docs/logo.png

--- a/charts/fuse/Chart.yaml
+++ b/charts/fuse/Chart.yaml
@@ -19,3 +19,8 @@ dependencies:
     version: ~11.1.24
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x

--- a/charts/fuse/values.yaml
+++ b/charts/fuse/values.yaml
@@ -86,9 +86,19 @@ tolerations: []
 
 affinity: {}
 
-global:
-  postgresql:
-    enabled: false
-    auth:
-      postgresPassword: "password"
-      database: postgres
+postgresql:
+# https://github.com/bitnami/charts/tree/master/bitnami/postgresql
+  enabled: false
+  auth:
+    ## @param auth.postgresPassword Password for the "postgres" admin user. Ignored if `auth.existingSecret` with key `postgres-password` is provided
+    postgresPassword: ""
+    ## @param auth.username Name for a custom user to create
+    username: ""
+    ## @param auth.password Password for the custom user to create. Ignored if `auth.existingSecret` with key `password` is provided
+    password: ""
+    ## @param auth.database Name for a custom database to create
+    database: ""
+    ## @param auth.replicationUsername Name of the replication user
+    existingSecret: ""
+    ## @param auth.existingSecret Name of existing secret to use for PostgreSQL credentials. The secret must contain the keys `postgres-password` (which is the password for "postgres" admin user), `password` (which is the password for the custom user to create when `auth.username` is set) and `replication-password` (which is the password for replication user). `auth.postgresPassword`, `auth.password`, and `auth.replicationPassword` will be ignored and picked up from this secret. The secret might also contains the key `ldap-password` if LDAP is enabled. `ldap.bind_password` will be ignored and picked from this secret in this case.
+    ## The value is evaluated as a template.


### PR DESCRIPTION
`global` is global for the locally scoped chart, so we need to instead stub out a `postgresql` section and then use the underlying auth section (and parameters) - adds those parameters and puts comments in them about what they control

Also adds the bitnami common pin as we'll need this later