### PR TITLE
fix: secret handling in fuse deployment

### DIFF
--- a/charts/fuse/Chart.lock
+++ b/charts/fuse/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.28
+  version: 11.1.29
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.13.1
-digest: sha256:87654f06705916fb140b683cae174a62584c50749aab52849fc96d53c0a8321c
-generated: "2022-05-12T12:25:37.246099-04:00"
+  version: 1.14.1
+digest: sha256:b62d4481165109ad807e9f9c64221b2677db1edae25156f200f74964738de8bd
+generated: "2022-05-24T18:13:56.983248-04:00"

--- a/charts/fuse/Chart.yaml
+++ b/charts/fuse/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fuse
-version: 1.0.7
-appVersion: 1.0.7
+version: 1.0.8
+appVersion: 1.0.8
 description: Fuse syncs data from Git into a SQL database for use in BI/visualization/other tools.
 home: https://www.mergestat.com/
 icon: https://github.com/mergestat/mergestat/blob/main/docs/logo.png

--- a/charts/fuse/templates/deployment.yaml
+++ b/charts/fuse/templates/deployment.yaml
@@ -35,9 +35,9 @@ spec:
           env:
             - name: POSTGRES_CONNECTION
               value: postgres://{{ .Values.postgresql.auth.username | default "postgres" }}:{{ .Values.postgresql.auth.postgresPassword }}@fuse-postgresql:5432/{{ .Values.postgresql.auth.database | default "postgres" }}?sslmode=disable
-          {{- if .Values.fuse.envFrom }}
-          envFrom: {{- include "common.tplvalues.render" (dict "value" .Values.fuse.envFrom "context" $ ) | nindent 12 }}
-          {{- end }}
+            {{- if .Values.fuse.env }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.fuse.env "context" $ ) | nindent 12 }}
+            {{- end }}
       containers:
         - name: {{ .Chart.Name }}-worker
           securityContext:
@@ -61,9 +61,9 @@ spec:
             - name: POSTGRES_CONNECTION
               # default if none is supplied, assumes pg is running with default values as well
               value: postgres://{{ .Values.postgresql.auth.username | default "postgres" }}:{{ .Values.postgresql.auth.postgresPassword }}@fuse-postgresql:5432/{{ .Values.postgresql.auth.database | default "postgres" }}?sslmode=disable
-          {{- if .Values.fuse.envFrom }}
-          envFrom: {{- include "common.tplvalues.render" (dict "value" .Values.fuse.envFrom "context" $ ) | nindent 12 }}
-          {{- end }}
+            {{- if .Values.fuse.env }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.fuse.env "context" $ ) | nindent 12 }}
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/fuse/values.yaml
+++ b/charts/fuse/values.yaml
@@ -16,9 +16,12 @@ fuse:
 
   # GITHUB_TOKEN env should be set
   # POSTGRES_CONNECTION may also be overridden
-  envFrom:
-    - secretRef:
-        name: fuse-secret
+  env:
+    - name: GITHUB_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: fuse-secret
+          key: GITHUB_TOKEN
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
addresses some precedence issues using `envFrom` in prior version, to allow an override in a downstream use case/test