### PR TITLE
Add pvc option for the fuse worker deployment

### DIFF
--- a/charts/fuse/Chart.yaml
+++ b/charts/fuse/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fuse
-version: 1.0.9
-appVersion: 1.0.9
+version: 1.1.0
+appVersion: 1.1.0
 description: Fuse syncs data from Git into a SQL database for use in BI/visualization/other tools.
 home: https://www.mergestat.com/
 icon: https://github.com/mergestat/mergestat/blob/main/docs/logo.png

--- a/charts/fuse/templates/deployment.yaml
+++ b/charts/fuse/templates/deployment.yaml
@@ -59,6 +59,17 @@ spec:
             {{- if .Values.fuse.env }}
             {{- include "common.tplvalues.render" (dict "value" .Values.fuse.env "context" $ ) | nindent 12 }}
             {{- end }}
+          {{- if .Values.persistence.enabled }}
+          volumeMounts:
+            - name: fuse-worker-tmp
+              mountPath: /tmp
+          {{- end }}
+      {{- if .Values.persistence.enabled }}
+      volumes:
+        - name: fuse-worker-tmp
+          persistentVolumeClaim:
+            claimName: {{ include "fuse.fullname" . }}-tmp
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/fuse/templates/pvc.yaml
+++ b/charts/fuse/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "fuse.fullname" . }}-tmp
+  labels:
+    {{- include "fuse.labels" . | nindent 4 }}
+spec:
+{{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+{{- end }}
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/fuse/values.yaml
+++ b/charts/fuse/values.yaml
@@ -108,3 +108,9 @@ postgresql:
     existingSecret: ""
     ## @param auth.existingSecret Name of existing secret to use for PostgreSQL credentials. The secret must contain the keys `postgres-password` (which is the password for "postgres" admin user), `password` (which is the password for the custom user to create when `auth.username` is set) and `replication-password` (which is the password for replication user). `auth.postgresPassword`, `auth.password`, and `auth.replicationPassword` will be ignored and picked up from this secret. The secret might also contains the key `ldap-password` if LDAP is enabled. `ldap.bind_password` will be ignored and picked from this secret in this case.
     ## The value is evaluated as a template.
+
+persistence:
+  enabled: false
+  # storageCLass: "-"
+  accessMode: ReadWriteOnce
+  size: 20Gi


### PR DESCRIPTION
This will add the option to give the fuse worker container in the fuse deployment some storage as when adding large git repos it starts to take up a lot of disk space within the pod.