### PR TITLE
feat: Add optional annotations for the pvc

### DIFF
--- a/charts/fuse/Chart.yaml
+++ b/charts/fuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fuse
-version: 1.2.10
+version: 1.2.11
 appVersion: sha-3037aa1
 description: Fuse syncs data from Git into a SQL database for use in BI/visualization/other tools.
 home: https://www.mergestat.com/

--- a/charts/fuse/templates/worker/pvc.yaml
+++ b/charts/fuse/templates/worker/pvc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "fuse.fullname" . }}-worker-tmp
   {{- with .Values.worker.persistence.annotations }}
   annotations:
-    {{- . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     {{- include "fuse.labels" . | nindent 4 }}

--- a/charts/fuse/values.yaml
+++ b/charts/fuse/values.yaml
@@ -18,6 +18,9 @@ worker:
   podAnnotations: {}
   persistence:
     enabled: false
+    annotations: {}
+      ## Example usage for github.com/topolvm/pvc-autoresizer
+      # resize.topolvm.io/storage_limit: 2Ti
     # storageClass: "-"
     accessMode: ReadWriteOnce
     size: 20Gi


### PR DESCRIPTION
# Sumary 

I use https://github.com/topolvm/pvc-autoresizer in my env. This would allow that use case in a generic, non-breaking way.

# Testing
Locally running `helm template . ` with custom values:
``` yaml
---
# Source: fuse/templates/worker/pvc.yaml
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: release-name-fuse-worker-tmp
  annotations:
    resize.topolvm.io/storage_limit: 2Ti
  labels:
    helm.sh/chart: fuse-1.2.11
    app.kubernetes.io/name: fuse
....
```