### PR TITLE
feat: bump `fuse` chart, using version tag

### DIFF
--- a/charts/fuse/Chart.yaml
+++ b/charts/fuse/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fuse
-version: 1.2.11
-appVersion: sha-3037aa1
+version: 1.2.12
+appVersion: v0.0.1
 description: Fuse syncs data from Git into a SQL database for use in BI/visualization/other tools.
 home: https://www.mergestat.com/
 icon: https://github.com/mergestat/mergestat/blob/main/docs/logo.png


### PR DESCRIPTION
https://github.com/mergestat/fuse/compare/3037aa1...v0.0.1