### PR TITLE
chore: bump `fuse` version to `0.0.6`

### DIFF
--- a/charts/fuse/Chart.yaml
+++ b/charts/fuse/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fuse
-version: 1.2.17
-appVersion: 0.0.5
+version: 1.2.18
+appVersion: 0.0.6
 description: Fuse syncs data from Git into a SQL database for use in BI/visualization/other tools.
 home: https://www.mergestat.com/
 icon: https://github.com/mergestat/mergestat/blob/main/docs/logo.png


### PR DESCRIPTION
https://github.com/mergestat/fuse/releases/tag/v0.0.6