### PR TITLE
chore: bump `fuse` version to `0.0.7`

### DIFF
--- a/charts/fuse/Chart.yaml
+++ b/charts/fuse/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fuse
-version: 1.2.18
-appVersion: 0.0.6
+version: 1.2.19
+appVersion: 0.0.7
 description: Fuse syncs data from Git into a SQL database for use in BI/visualization/other tools.
 home: https://www.mergestat.com/
 icon: https://github.com/mergestat/mergestat/blob/main/docs/logo.png


### PR DESCRIPTION
Updating fuse version from 0.0.6 to 0.0.7