### PR TITLE
chore: bump `fuse` version to `0.0.8`

### DIFF
--- a/charts/fuse/Chart.yaml
+++ b/charts/fuse/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fuse
-version: 1.2.19
-appVersion: 0.0.7
+version: 1.2.20
+appVersion: 0.0.8
 description: Fuse syncs data from Git into a SQL database for use in BI/visualization/other tools.
 home: https://www.mergestat.com/
 icon: https://github.com/mergestat/mergestat/blob/main/docs/logo.png


### PR DESCRIPTION
Updating fuse from 0.0.7 to 0.0.8