### PR TITLE
fix: include `service-credentials` graphql extension

### DIFF
--- a/charts/fuse/Chart.yaml
+++ b/charts/fuse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fuse
-version: 1.2.21
+version: 1.2.22
 appVersion: 0.0.8
 description: Fuse syncs data from Git into a SQL database for use in BI/visualization/other tools.
 home: https://www.mergestat.com/

--- a/charts/fuse/templates/graphql/deployment.yaml
+++ b/charts/fuse/templates/graphql/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - "--schema"
             - "mergestat,public"
             - "--append-plugins"
-            - "@graphile-contrib/pg-simplify-inflector,postgraphile-plugin-connection-filter,/graphql/exec-sql/index.js"
+            - "@graphile-contrib/pg-simplify-inflector,postgraphile-plugin-connection-filter,/graphql/exec-sql/index.js,/graphql/service-credentials/index.js"
             - "-o"
             - "--subscriptions"
             - "--retry-on-init-fail"


### PR DESCRIPTION
So we're now including the service credentials functionality graphql extension