### PR TITLE
chore: bump `fuse` version to latest

### DIFF
--- a/charts/fuse/Chart.yaml
+++ b/charts/fuse/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fuse
-version: 1.2.25
-appVersion: 0.0.8
+version: 1.3.0
+appVersion: 0.1.0
 description: Fuse syncs data from Git into a SQL database for use in BI/visualization/other tools.
 home: https://www.mergestat.com/
 icon: https://github.com/mergestat/mergestat/blob/main/docs/logo.png


### PR DESCRIPTION
to `v0.1.0`