### PR TITLE
chore: bump `mergestat` chart to `v1.6.0-beta`

### DIFF
--- a/charts/mergestat/Chart.yaml
+++ b/charts/mergestat/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mergestat
-version: 1.6.4
-appVersion: 1.5.4-beta
+version: 1.7.0
+appVersion: 1.6.0-beta
 description: MergeStat syncs data from Git into a SQL database for use in BI/visualization/other tools.
 home: https://www.mergestat.com/
 icon: https://github.com/mergestat/mergestat/blob/main/docs/logo.png


### PR DESCRIPTION
https://github.com/mergestat/mergestat/releases/tag/v1.6.0-beta