### PR TITLE
chore: set the `-lock-timeout` flag when running migrations in the `init` container

### DIFF
--- a/charts/mergestat/Chart.yaml
+++ b/charts/mergestat/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: mergestat
-version: 1.7.0
+version: 1.7.1
 appVersion: 1.6.0-beta
 description: MergeStat syncs data from Git into a SQL database for use in BI/visualization/other tools.
 home: https://www.mergestat.com/

--- a/charts/mergestat/templates/worker/deployment.yaml
+++ b/charts/mergestat/templates/worker/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Chart.Name }}-worker-init
           image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag | default .Chart.AppVersion }}"
           command: [/usr/local/bin/migrate]
-          args: ["-database", "$(POSTGRES_CONNECTION)", "-path", "migrations", "up"]
+          args: ["-database", "$(POSTGRES_CONNECTION)", "-path", "migrations", "up", "-lock-timeout=300"]
           env:
             {{- if .Values.worker.env }}
             {{- include "common.tplvalues.render" (dict "value" .Values.worker.env "context" $ ) | nindent 12 }}


### PR DESCRIPTION
to `300` (seconds) instead of the default of `15`.

```
-lock-timeout N  Allow N seconds to acquire database lock (default 15)
```

Maybe a smaller number is better...but leaving a placeholder here for @amenowanna - let me know what you think as a way to address https://github.com/mergestat/mergestat/issues/611