### PR TITLE
fix: order of `-lock-timeout` flag in init container (migration)

### DIFF
--- a/charts/mergestat/Chart.yaml
+++ b/charts/mergestat/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: mergestat
-version: 1.8.0
+version: 1.8.1
 appVersion: 1.7.0-beta
 description: MergeStat syncs data from Git into a SQL database for use in BI/visualization/other tools.
 home: https://www.mergestat.com/

--- a/charts/mergestat/templates/worker/deployment.yaml
+++ b/charts/mergestat/templates/worker/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Chart.Name }}-worker-init
           image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag | default .Chart.AppVersion }}"
           command: [/usr/local/bin/migrate]
-          args: ["-database", "$(POSTGRES_CONNECTION)", "-path", "migrations", "up", "-lock-timeout=300"]
+          args: ["-database", "$(POSTGRES_CONNECTION)", "-path", "migrations", "-lock-timeout=300", "up"]
           env:
             {{- if .Values.worker.env }}
             {{- include "common.tplvalues.render" (dict "value" .Values.worker.env "context" $ ) | nindent 12 }}


### PR DESCRIPTION
Should fix our call of the `migrate` CLI