### PR TITLE
remove default for replicas to allow 0 replicas

### DIFF
--- a/charts/mergestat/templates/console/deployment.yaml
+++ b/charts/mergestat/templates/console/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "mergestat.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.ui.replicaCount | default 1 }}
+  replicas: {{ .Values.ui.replicaCount }}
   selector:
     matchLabels:
       {{- include "mergestat.selectorLabels" . | nindent 6 }}

--- a/charts/mergestat/templates/graphql/deployment.yaml
+++ b/charts/mergestat/templates/graphql/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "mergestat.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.graphql.replicaCount | default 1 }}
+  replicas: {{ .Values.graphql.replicaCount }}
   selector:
     matchLabels:
       {{- include "mergestat.selectorLabels" . | nindent 6 }}

--- a/charts/mergestat/templates/worker/deployment.yaml
+++ b/charts/mergestat/templates/worker/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "mergestat.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.worker.replicaCount | default 1 }}
+  replicas: {{ .Values.worker.replicaCount }}
   selector:
     matchLabels:
       {{- include "mergestat.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
When replicaCount is 0 default replaces with the provided value, which can give unexpected results.